### PR TITLE
- Unifica el modo en que se injectan las variables de entorno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-PGHOST=localhost
-PGUSER=user
-PGPASSWORD=password
-PGDATABASE=database
-PGPORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         PGPASSWORD: ${{ secrets.DB_PASSWORD_TEST }}
 
     - name: Ejecutar Tests
-      run: npm run test
+      run: npm run ci_test
       env:
         # Las variables de entorno necesarias para los tests
         PGHOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,5 @@ jobs:
         PGPASSWORD: ${{ secrets.DB_PASSWORD_TEST }}
         PGDATABASE: aida
         PGPORT: 5432
-        IS_DEVELOPMENT: true
+        NODE_ENV: test
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ views/plantilla-tabla*.html
 local-*
 *-local.*
 *-local
-.env
+.env.development
+.env.test
 certificado-para-imprimir.html
 certificado-de-*-para-imprimir.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
         "@types/pdfmake": "^0.2.12",
         "@types/pg": "^8.15.5",
         "@types/supertest": "^6.0.3",
-        "cross-env": "^10.1.0",
-        "dotenv": "^17.2.3",
         "mocha": "^11.3.0",
         "supertest": "^7.2.2",
         "typescript": "^5.9.2"
@@ -32,13 +30,6 @@
       "engines": {
         "node": "22.19.0"
       }
-    },
-    "node_modules/@epic-web/invariant": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@foliojs-fork/fontkit": {
       "version": "1.9.2",
@@ -789,24 +780,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-env": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@epic-web/invariant": "^1.0.0",
-        "cross-spawn": "^7.0.6"
-      },
-      "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -956,19 +929,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -21,17 +21,15 @@
     "@types/pdfmake": "^0.2.12",
     "@types/pg": "^8.15.5",
     "@types/supertest": "^6.0.3",
-    "cross-env": "^10.1.0",
-    "dotenv": "^17.2.3",
     "mocha": "^11.3.0",
     "supertest": "^7.2.2",
     "typescript": "^5.9.2"
   },
   "scripts": {
     "prepare": "tsc -p src/tsconfig.json",
-    "dev": "npm run prepare && node dist/server.js",
+    "dev": "npm run prepare && node --env-file=.env.development dist/server.js",
     "start": "npm run prepare && node dist/server.js",
-    "test": "tsc -p test/tsconfig.json && cross-env NODE_ENV=test mocha --enable-source-maps --reporter spec --bail --check-leaks dist-test/test/test.js --exit",
+    "test": "tsc -p test/tsconfig.json && node --env-file=.env.test node_modules/.bin/mocha --enable-source-maps --reporter spec --bail --check-leaks dist-test/test/test.js --exit",
     "x-test": "mocha --reporter spec --bail --check-leaks test/test.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "npm run prepare && node --env-file=.env.development dist/server.js",
     "start": "npm run prepare && node dist/server.js",
     "test": "tsc -p test/tsconfig.json && node --env-file=.env.test node_modules/.bin/mocha --enable-source-maps --reporter spec --bail --check-leaks dist-test/test/test.js --exit",
+    "ci_test": "tsc -p test/tsconfig.json && node_modules/.bin/mocha --enable-source-maps --reporter spec --bail --check-leaks dist-test/test/test.js --exit",
     "x-test": "mocha --reporter spec --bail --check-leaks test/test.ts"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,9 @@
-import 'dotenv/config'; // Carga las variables del .env, se acceden con process.env
-
-const env = process.env.NODE_ENV || 'development';  // NODE_ENV en render es 'production' por defecto
+if (!process.env.NODE_ENV) {
+  throw new Error('NODE_ENV is not set');
+}
 
 export const config = {
-  env: env,
+  env: process.env.NODE_ENV,
   port: Number(process.env.PORT) || 3000,
   db: {
     user: process.env.PGUSER,
@@ -11,6 +11,6 @@ export const config = {
     password: process.env.PGPASSWORD,
     port: Number(process.env.PGPORT) || 5432,
     database: process.env.PGDATABASE,
-    url: process.env.DATABASE_URL   // Para producción
+    url: process.env.DATABASE_URL
   }
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import * as assert from "assert";
 import request from 'supertest';
 import app from '../src/app.js'; // Tu instancia de express


### PR DESCRIPTION
Ahora, tanto en entorno de desarrollo como de test, se cargan desde el .env correspondiente en el script de node.

- Como ya no se inyectan las variables de entorno desde el código, se desinstala el paquete dotenv (y eliminan sus import statements).
- Además, como ya no se setean variables de entorno individuales desde el script de testing, se desinstala el paquete cross-env.